### PR TITLE
Fix issues for Node.js 20.x

### DIFF
--- a/chapter-2/twentyfour-hour-video/transcode-video/index.js
+++ b/chapter-2/twentyfour-hour-video/transcode-video/index.js
@@ -7,8 +7,8 @@
 
 'use strict';
 
-const AWS = require('aws-sdk');
-const mediaConvert = new AWS.MediaConvert({
+const { MediaConvertClient, CreateJobCommand } = require("@aws-sdk/client-mediaconvert");
+const mediaConvert = new MediaConvertClient({
     endpoint: process.env.MEDIA_ENDPOINT                
 });
 
@@ -61,7 +61,7 @@ exports.handler = async (event, context) => {
             }
         };
 
-        const mediaConvertResult = await mediaConvert.createJob(job).promise();           
+	const mediaConvertResult = await mediaConvert.send(new CreateJobCommand(job));
         console.log(mediaConvertResult);
 
     } catch (error) {


### PR DESCRIPTION
The interface for the MediaConverter has changed since the book was published. These changes make it work with the Node.js 20.x Lambda environment.

In addition to these changes, it was also necessary to add "[AdministratorAccess](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/policies/details/arn%3Aaws%3Aiam%3A%3Aaws%3Apolicy%2FAdministratorAccess)" to the `transcode-video` role to get around a `"iam:PassRole"` permissions error